### PR TITLE
CI: Upgrade clang-format-check action v3.3.0 -> v4.11.0

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,7 +20,7 @@ jobs:
       shell: bash
 
     - name: Check code formatting
-      uses: jidicula/clang-format-action@v3.3.0
+      uses: jidicula/clang-format-action@v4.11.0
       with:
           clang-format-version: '10'
           check-path: '.'


### PR DESCRIPTION
Fixes always-failing workflow