### PR TITLE
CI: Build on macos 13 (replace outdated 10.15)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-13]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
10 is no longer available https://github.com/actions/runner-images/blob/main/README.md